### PR TITLE
Agregue la authentication con google serivces

### DIFF
--- a/Autenticacion/build.gradle.kts
+++ b/Autenticacion/build.gradle.kts
@@ -59,4 +59,9 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    // google
+    implementation("com.google.android.gms:play-services-auth:20.7.0") 
+    implementation("com.google.firebase:firebase-auth-ktx")
+
 }

--- a/Autenticacion/src/main/java/login/Login.kt
+++ b/Autenticacion/src/main/java/login/Login.kt
@@ -1,13 +1,21 @@
 package login
 
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.common.api.ApiException
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.GoogleAuthProvider
+import kotlinx.coroutines.launch
 
 @Composable
 fun AuthScreen(auth: FirebaseAuth, onSuccess: () -> Unit) {
@@ -15,16 +23,42 @@ fun AuthScreen(auth: FirebaseAuth, onSuccess: () -> Unit) {
     var password by remember { mutableStateOf("") }
     val context = LocalContext.current
 
+    // Configuración de Google Sign-In
+    val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+        .requestIdToken("955903094104-b0hfdtapvq95l4l8ukisk17h1nhmnkv0.apps.googleusercontent.com")
+        .requestEmail()
+        .build()
+    val googleSignInClient: GoogleSignInClient = GoogleSignIn.getClient(context, gso)
+
+    // Launcher para Google Sign-In
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
+        try {
+            val account = task.getResult(ApiException::class.java)
+            val credential = GoogleAuthProvider.getCredential(account.idToken, null)
+            auth.signInWithCredential(credential)
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        Toast.makeText(context, "Inicio de sesión con Google exitoso", Toast.LENGTH_SHORT).show()
+                        onSuccess() // Navegación directa
+                    } else {
+                        Toast.makeText(context, "Firebase Auth fallo: ${task.exception?.message}", Toast.LENGTH_LONG).show()
+                    }
+                }
+        } catch (e: ApiException) {
+            Toast.makeText(context, "Google Sign-In fallo: ${e.statusCode} - ${e.message}", Toast.LENGTH_LONG).show()
+        }
+    }
+
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier = Modifier.fillMaxSize().padding(16.dp),
         verticalArrangement = Arrangement.Center
     ) {
         TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
         Spacer(Modifier.height(8.dp))
         TextField(value = password, onValueChange = { password = it }, label = { Text("Password") })
-
         Spacer(Modifier.height(16.dp))
 
         Button(onClick = {
@@ -39,23 +73,13 @@ fun AuthScreen(auth: FirebaseAuth, onSuccess: () -> Unit) {
 
         Spacer(Modifier.height(8.dp))
 
-        Button(onClick = {
-            // TODO: Google Sign-In
-        }, modifier = Modifier.fillMaxWidth()) {
+        Button(onClick = { launcher.launch(googleSignInClient.signInIntent) },
+            modifier = Modifier.fillMaxWidth()) {
             Text("Iniciar sesión con Google")
         }
 
         Spacer(Modifier.height(8.dp))
 
-        Button(onClick = {
-            // TODO: Xbox / PSN SDK
-        }, modifier = Modifier.fillMaxWidth()) {
-            Text("Iniciar sesión con Xbox/PSN")
-        }
-
-        Spacer(Modifier.height(8.dp))
-
-        // 🔹 Botón de Registro
         Button(onClick = {
             auth.createUserWithEmailAndPassword(email, password)
                 .addOnSuccessListener {
@@ -70,3 +94,4 @@ fun AuthScreen(auth: FirebaseAuth, onSuccess: () -> Unit) {
         }
     }
 }
+

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -7,12 +7,20 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:955903094104:android:d1df87887e9be5ca7b092d",
+        "mobilesdk_app_id": "1:955903094104:android:12846648b06bb0977b092d",
         "android_client_info": {
           "package_name": "com.example.ClaseBeforeProject"
         }
       },
       "oauth_client": [
+        {
+          "client_id": "955903094104-0m17r1heldbf2n07vh61l7h60q2oekad.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.example.ClaseBeforeProject",
+            "certificate_hash": "0a7ed55e9a942515732c20013c89e830c4573d53"
+          }
+        },
         {
           "client_id": "955903094104-b0hfdtapvq95l4l8ukisk17h1nhmnkv0.apps.googleusercontent.com",
           "client_type": 3


### PR DESCRIPTION
## Summary by Sourcery

Enable Google authentication in the AuthScreen by configuring GoogleSignInClient, handling the activity result, and wiring the credential to FirebaseAuth, along with adding necessary dependencies and removing unused sign-in placeholders.

New Features:
- Integrate Google Sign-In into the authentication screen with Firebase credential handling
- Launch the Google Sign-In flow and handle success/failure callbacks within the Compose UI

Enhancements:
- Remove placeholder Xbox/PSN sign-in button
- Streamline AuthScreen layout modifiers

Build:
- Add Play Services Auth and Firebase Auth KTX dependencies

Chores:
- Add google-services.json configuration file